### PR TITLE
fixed Jekyll compilation errors

### DIFF
--- a/_chapters/chapters/transversal/wellbeing.md
+++ b/_chapters/chapters/transversal/wellbeing.md
@@ -1,6 +1,6 @@
 ---
 layout: reading_chapter
-title: Completing a Happy TEL PhD: Wellbeing in TEL Doctorates
+title: Completing a Happy TEL PhD&#58; Wellbeing in TEL Doctorates
 hide: false
 permalink: /chapter/transversal/wellbeing/
 ---
@@ -12,7 +12,7 @@ NEW *personal, narrative vignette?*
 ### Dropout in the doctorate
 
 content copied/adapted from [this post](https://ahappyphd.org/posts/drop-out-phd/)
-<!-- use {% include_relative separate_file.md %} -->
+
 <!-- include some link like "This piece first appeared in (link to original post)" -->
 
 ### Mental health in the doctorate


### PR DESCRIPTION
A chapter contained bad formatting so that Jekyll could not compile the book anymore. I fixed the following:

- In the pre-matter (between the `---`), there may not be a colon in the chapter title. Instead, it needs to be escaped with `&#58;`.
- There was a commented out include command. Apparently, Jekyll has a bug where it still picks up such commands, even if they are commented out. I removed the command.