### PR TITLE
Added Social Meta Tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,14 @@ feed_url: https://ea-tel.eu/detel-book/feed.xml
 
 # Social Tags
 og_image: assets/images/Cover.png
+image: assets/images/Cover.png
+
+twitter:
+  username: eateleu
+  site: https://twitter.com/eateleu
+
+facebook:
+ publisher: https://www.facebook.com/eatel.eu
 
 # Google Analytics Tracking ID goes here:
 google_analytics:

--- a/_includes/social-metatags.html
+++ b/_includes/social-metatags.html
@@ -1,0 +1,152 @@
+<!-- Update your html tag to include the itemscope and itemtype attributes. -->
+<html itemscope itemtype="http://schema.org/Article">
+
+{% if page.title and page.layout == 'page' %}
+  {% assign page_title = page.title | append: ' | ' | append: site.title | escape %}
+{% elsif page.title %}
+ {% assign page_title = page.title | escape %}
+{% else %}
+ {% assign page_title = site.title | escape %}
+{% endif %}
+
+
+{% if page.author.name or page.facebook.publisher_id %}
+  {% assign page_author = page.author.name | default: nil | escape %}
+  {% assign facebook_publisher_id = page.facebook.publisher_id | default: nil | escape %}
+  {% assign twitter_creator = page.twitter.username | default: site.twitter.site | default: nil | escape %}
+  {% assign facebook_authors = page.facebook.authors | default: nil | escape %}
+{% else %}
+  {% assign page_author = site.author.name | default: nil | escape %}
+  {% assign facebook_publisher_id = site.facebook.publisher_id | default: nil | escape %}
+  {% assign twitter_creator = site.twitter.username | default: nil | escape %}
+  {% assign facebook_authors = site.facebook.authors | default: nil | escape %}
+{% endif %}
+
+{% assign page_description = page.excerpt | default: page.tagline | default: site.description | strip_html | normalize_whitespace | truncate: 300 | escape %}
+
+{%if page.image %}
+  {% assign page_image = site.url | append: site.baseurl | append: page.image %}
+{%else if site.image %}
+  {% assign page_image = site.url | append: site.baseurl | append: site.image %}
+{%endif %}
+
+{% assign canonical_url = page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
+
+<!-- Place this data between the <head> tags of your website -->
+{%if page_author %}
+  <meta name="author" content="{{ page_author }}" />
+{%endif %}
+<meta name="description" content="{{ page_description }}" />
+{%if page.tags.size > 0 %}
+  <meta name="keywords" itemprop="tags" content="{{ page.tags | join: ', ' | escape }}"/>
+{%endif %}
+{%if page.keywords %}
+  <meta name="keywords" itemprop="keywords" content="{{ page.keywords | escape  }}" />
+{%endif %}
+{%if page.categories.size > 0 %}
+  <meta name="keywords" itemprop="categories" content="{{ page.categories | join: ', ' | escape  }}" />
+{%endif %}
+{%if page.category %}
+  <meta name="keywords" itemprop="category" content="{{ category | escape  }}" />
+{%endif %}
+
+<!-- Schema.org markup for Google+ -->
+<meta itemprop="name" content="{{ page_title }}" />
+<meta itemprop="description" content="{{ page_description }}" />
+{%if page_image %}
+  <meta itemprop="image" content="{{ page_image }}" />
+{%endif %}
+
+<!-- Twitter Card data -->
+<meta name="twitter:card" content="summary_large_image" />
+
+{%if site.twitter.site %}
+  <meta name="twitter:site" content="@{{ site.twitter.site }}" />
+{%endif %}
+
+<meta name="twitter:title" content="{{ page_title }}" />
+<meta name="twitter:description" content="{{ page_description }}" />
+
+{%if twitter_creator %}
+  <meta name="twitter:creator" content="@{{ twitter_creator }}" />
+{%endif %}
+
+<!-- Twitter summary card with large image must be at least 280x150px -->
+{%if page_image %}
+  <meta name="twitter:image:src" content="{{ page_image }}" />
+  <meta name="twitter:image" content="{{ page_image }}" />
+{%endif %}
+<meta name="twitter:url" content="{{ canonical_url }}" />
+
+<!-- Open Graph data -->
+<meta property="og:title" content="{{ page_title }}" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="{{ canonical_url }}" />
+{%if page_image %}
+  <meta property="og:image" content="{{ page_image }}" />
+{%endif %}
+<meta property="og:description" content="{{ page_description }}" />
+<meta property="og:site_name" content="{{ site.title }}" />
+
+{% if page-lang == "en" %}
+  {% assign page-lang-country = "en_US" %}
+{% elsif page-lang == "it" %}
+  {% assign page-lang-country = "it_IT" %}
+{% endif %}
+<meta property="og:locale" content="{{ page-lang-country }}" />
+
+{%if page.date %}
+  <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
+{%endif %}
+{%if page.modified_date %}
+  <meta property="article:modified_time" content="{{ page.modified_date | date_to_xmlschema }}" />
+{%endif %}
+
+{%if site.facebook.admins %}
+  {% for admin in site.facebook.admins %}
+    <meta property="fb:admins" content="{{ admin }}" />
+  {% endfor %}
+{%endif %}
+
+{%if site.facebook.app_id %}
+  <meta property="fb:app_id" content="{{ site.facebook.app_id }}" />
+{%endif %}
+
+{%if site.facebook.profile_id %}
+  <meta property="fb:profile_id" content="{{ site.facebook.profile_id }}" />
+{%endif %}
+
+{%if facebook_publisher_id %}
+  <meta property="article:publisher" content="https://www.facebook.com/{{ facebook_publisher_id }}" />
+  <meta property="fb:pages" content="{{ facebook_publisher_id }}" />
+{%endif %}
+
+{%if facebook_authors %}
+  {% for fb_author in facebook_authors %}
+    <meta property="article:author" content="https://www.facebook.com/{{ fb_author }}" />
+  {% endfor %}
+{%endif %}
+
+
+{%if page.tags %}
+  {% for tag in page.tags %}
+    <meta property="article:tag" content="{{ tag | escape }}" />
+  {% endfor %}
+{%endif %}
+
+{%if page.keywords %}
+  {% assign keywordsList = page.keywords | split:', ' %}
+  {% for keyword in keywordsList %}
+    <meta property="article:tag" content="{{ keyword | escape }}" />
+  {% endfor %}
+{%endif %}
+
+{%if page.categories %}
+  {% for category in page.categories %}
+    <meta property="article:tag" content="{{ category | escape }}" />
+  {% endfor %}
+{%endif %}
+
+{%if page.category %}
+  <meta property="article:tag" content="{{ category | escape }}" />
+{%endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@ Jekyll integration by Chris Bobbe | chrisbobbe.github.io
 -->
 <html>
 	{%- include head.html -%}
+	{% include social-metatags.html %}
 	<body>
 		{{- content -}}
 		{%- include footer.html -%}


### PR DESCRIPTION
In this small pull-request we added an include file [this repository](https://github.com/lorepirri/jekyll-social-metatags) that is supposed to make the social meta tags including an image show up. However, since we cannot test this until its merged and live on the website, its functionality is uncertain.