### PR TITLE
Social meta tags fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ gem "kramdown-parser-gfm"
 #gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'jekyll-scholar'
 gem 'jekyll-redirect-from'
+gem 'jekyll-seo-tag'
 gemspec

--- a/_config.yml
+++ b/_config.yml
@@ -59,6 +59,7 @@ feed_url: https://ea-tel.eu/detel-book/feed.xml
 # Social Tags
 og_image: assets/images/Cover.png
 image: assets/images/Cover.png
+logo: assets/images/Cover.png
 
 twitter:
   username: eateleu
@@ -90,3 +91,4 @@ scholar:
 
 plugins:
   - jekyll-redirect-from
+  - jekyll-seo-tag

--- a/_config.yml
+++ b/_config.yml
@@ -57,9 +57,9 @@ dribbble_url:
 feed_url: https://ea-tel.eu/detel-book/feed.xml
 
 # Social Tags
-og_image: assets/images/Cover.png
-image: assets/images/Cover.png
-logo: assets/images/Cover.png
+og_image: /assets/images/Cover.png
+image: /assets/images/Cover.png
+logo: /assets/images/Cover.png
 
 twitter:
   username: eateleu

--- a/_config.yml
+++ b/_config.yml
@@ -36,11 +36,11 @@ description: >- # this means to ignore newlines until "baseurl:"
   The Open book on Doctoral Education in Technology Enhanced Learning (DETEL book) is an open educational resource for doctoral candidates working in the field of Technology-Enhanced Learning or TEL (also known as Educational Technology, Digitl Education, Learning Engineering) and related fields.
 author: Ralf Klamma
 email: klamma@dbis.rwth-aachen.de
-avatar: assets/images/avatar.png
+avatar: /assets/images/avatar.png
 
 # You'll want to customize url and baseurl for your own site:
 baseurl: "/detel-book" # the subpath of your site, e.g. /blog
-url: "https://ea-tel.eu" # the base hostname & protocol for your site
+url: "https://ea-tel.github.io" # the base hostname & protocol for your site
 
 # Social settings
 # Make sure to include the full url including protocol, e.g. https://github.com/chrisbobbe

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,13 @@ Jekyll integration by Chris Bobbe | chrisbobbe.github.io
 <html>
 	{%- include head.html -%}
 	{% include social-metatags.html %}
+	<head>
+		<!-- {% raw %} -->
+			```liquid
+			{% seo %}
+			```
+	  	<!-- {% endraw %} -->
+	</head>
 	<body>
 		{{- content -}}
 		{%- include footer.html -%}


### PR DESCRIPTION
Since the social meta tags still didn't work after the last pull-request, we added a new plugin and fixed some formatting errors that prevented the tags to be read correctly. We tested the feature via Github Pages on the fork and the social meta tag check presented this result. Thus the issue should be resolved now. Closes #32.
![smt](https://user-images.githubusercontent.com/19326682/203548877-75fb2341-90d5-4c37-947a-6c3ebb3fce63.png)
