### PR TITLE
Social meta tags fixed on Discord and Facebook

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,8 @@ description: >- # this means to ignore newlines until "baseurl:"
   The Open book on Doctoral Education in Technology Enhanced Learning (DETEL book) is an open educational resource for doctoral candidates working in the field of Technology-Enhanced Learning or TEL (also known as Educational Technology, Digitl Education, Learning Engineering) and related fields.
 author: Ralf Klamma
 email: klamma@dbis.rwth-aachen.de
-avatar: /assets/images/avatar.png
+avatar: /assets/images/Cover.png
+sidebar_logo: /assets/images/avatar.png
 
 # You'll want to customize url and baseurl for your own site:
 baseurl: "/detel-book" # the subpath of your site, e.g. /blog

--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,6 @@ description: >- # this means to ignore newlines until "baseurl:"
 author: Ralf Klamma
 email: klamma@dbis.rwth-aachen.de
 avatar: /assets/images/Cover.png
-sidebar_logo: /assets/images/avatar.png
 
 # You'll want to customize url and baseurl for your own site:
 baseurl: "/detel-book" # the subpath of your site, e.g. /blog
@@ -61,6 +60,8 @@ feed_url: https://ea-tel.eu/detel-book/feed.xml
 og_image: /assets/images/Cover.png
 image: /assets/images/Cover.png
 logo: /assets/images/Cover.png
+
+sidebar_logo: /assets/images/avatar.png
 
 twitter:
   username: eateleu

--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,6 @@ description: >- # this means to ignore newlines until "baseurl:"
   The Open book on Doctoral Education in Technology Enhanced Learning (DETEL book) is an open educational resource for doctoral candidates working in the field of Technology-Enhanced Learning or TEL (also known as Educational Technology, Digitl Education, Learning Engineering) and related fields.
 author: Ralf Klamma
 email: klamma@dbis.rwth-aachen.de
-avatar: /assets/images/Cover.png
 
 # You'll want to customize url and baseurl for your own site:
 baseurl: "/detel-book" # the subpath of your site, e.g. /blog
@@ -60,8 +59,6 @@ feed_url: https://ea-tel.eu/detel-book/feed.xml
 og_image: /assets/images/Cover.png
 image: /assets/images/Cover.png
 logo: /assets/images/Cover.png
-
-sidebar_logo: /assets/images/avatar.png
 
 twitter:
   username: eateleu

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,7 +23,7 @@
   <!-- Open Graph -->
   <meta property="og:title" content="{{- _page_title -}}" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="{{- site.avatar | absolute_url -}}" />
+  <meta property="og:image" content="{{- site.image | absolute_url -}}" />
   <meta property="og:url" content="{{- page.url | absolute_url -}}" />
   <meta property="og:site_name" content="{{- site.title | escape -}}" />
   <meta property="og:description" content="{{- _page_description -}}" />

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,7 +1,7 @@
 <!-- Logo -->
 <div id="logo">
   <a href="{{- '/' | absolute_url -}}" id="home-link">
-    <span class="image avatar48"><img src="{{- '/assets/images/avatar.png' | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
+    <span class="image avatar48"><img src=".../assets/images/avatar.png" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
     <h1 id="title">{{- site.title -}}</h1>
     <p>{{- site.subtitle -}}</p>
   </a>

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,6 +1,7 @@
 <!-- Logo -->
 <div id="logo">
   <a href="{{- '/' | absolute_url -}}" id="home-link">
+    <span class="image avatar48"><img src="{{- site.avatar | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
     <h1 id="title">{{- site.title -}}</h1>
     <p>{{- site.subtitle -}}</p>
   </a>

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,7 +1,7 @@
 <!-- Logo -->
 <div id="logo">
   <a href="{{- '/' | absolute_url -}}" id="home-link">
-    <span class="image avatar48"><img src="{{- /assets/images/avatar.png | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
+    <span class="image avatar48"><img src="{{- '/assets/images/avatar.png' | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
     <h1 id="title">{{- site.title -}}</h1>
     <p>{{- site.subtitle -}}</p>
   </a>

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,7 +1,7 @@
 <!-- Logo -->
 <div id="logo">
   <a href="{{- '/' | absolute_url -}}" id="home-link">
-    <span class="image avatar48"><img src="{{- site.avatar | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
+    <span class="image avatar48"><img src="{{- /assets/images/avatar.png | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
     <h1 id="title">{{- site.title -}}</h1>
     <p>{{- site.subtitle -}}</p>
   </a>

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,7 +1,7 @@
 <!-- Logo -->
 <div id="logo">
   <a href="{{- '/' | absolute_url -}}" id="home-link">
-    <span class="image avatar48"><img src="{{- site.sidebar_logo | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
+    <span class="image avatar48"><img src="{{- '/assets/images/avatar.png' | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
     <h1 id="title">{{- site.title -}}</h1>
     <p>{{- site.subtitle -}}</p>
   </a>

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,7 +1,7 @@
 <!-- Logo -->
 <div id="logo">
   <a href="{{- '/' | absolute_url -}}" id="home-link">
-    <span class="image avatar48"><img src=".../assets/images/avatar.png" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
+    <span class="image avatar48"><img src="assets/images/avatar.png" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
     <h1 id="title">{{- site.title -}}</h1>
     <p>{{- site.subtitle -}}</p>
   </a>

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,7 +1,6 @@
 <!-- Logo -->
 <div id="logo">
   <a href="{{- '/' | absolute_url -}}" id="home-link">
-    <span class="image avatar48"><img src="{{- '/assets/images/avatar.png' | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
     <h1 id="title">{{- site.title -}}</h1>
     <p>{{- site.subtitle -}}</p>
   </a>

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,7 +1,7 @@
 <!-- Logo -->
 <div id="logo">
   <a href="{{- '/' | absolute_url -}}" id="home-link">
-    <span class="image avatar48"><img src="{{- site.avatar | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
+    <span class="image avatar48"><img src="{{- site.sidebar_logo | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
     <h1 id="title">{{- site.title -}}</h1>
     <p>{{- site.subtitle -}}</p>
   </a>


### PR DESCRIPTION
This pull-request includes adjustments to the way the logo and cover are referenced such that the correct images are now displayed when posting links to the book on Discord and Facebook. Both have been tested and are working.