### PR TITLE
Finalizing Social Meta Tags

### DIFF
--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,7 +1,7 @@
 <!-- Logo -->
 <div id="logo">
   <a href="{{- '/' | absolute_url -}}" id="home-link">
-    <span class="image avatar48"><img src="assets/images/avatar.png" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
+    <span class="image avatar48"><img src="{{- 'assets/images/avatar.png' | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
     <h1 id="title">{{- site.title -}}</h1>
     <p>{{- site.subtitle -}}</p>
   </a>

--- a/_includes/social-metatags.html
+++ b/_includes/social-metatags.html
@@ -58,7 +58,7 @@
 {%endif %}
 
 <!-- Twitter Card data -->
-<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:card" content="{{ page_image }}" />
 
 {%if site.twitter.site %}
   <meta name="twitter:site" content="@{{ site.twitter.site }}" />

--- a/_includes/social-metatags.html
+++ b/_includes/social-metatags.html
@@ -13,12 +13,12 @@
 {% if page.author.name or page.facebook.publisher_id %}
   {% assign page_author = page.author.name | default: nil | escape %}
   {% assign facebook_publisher_id = page.facebook.publisher_id | default: nil | escape %}
-  <!--{% assign twitter_creator = page.twitter.username | default: site.twitter.site | default: nil | escape %}-->
+  {% assign twitter_creator = page.twitter.username | default: site.twitter.site | default: nil | escape %}
   {% assign facebook_authors = page.facebook.authors | default: nil | escape %}
 {% else %}
   {% assign page_author = site.author.name | default: nil | escape %}
   {% assign facebook_publisher_id = site.facebook.publisher_id | default: nil | escape %}
-  <!--{% assign twitter_creator = site.twitter.username | default: nil | escape %}-->
+  {% assign twitter_creator = site.twitter.username | default: nil | escape %}
   {% assign facebook_authors = site.facebook.authors | default: nil | escape %}
 {% endif %}
 
@@ -58,7 +58,7 @@
 {%endif %}
 
 <!-- Twitter Card data -->
-<!--<meta name="twitter:card" content="{{ page_image }}" />
+<meta name="twitter:card" content="summary_large_image" />
 
 {%if site.twitter.site %}
   <meta name="twitter:site" content="@{{ site.twitter.site }}" />
@@ -72,11 +72,11 @@
 {%endif %}
 
 <!-- Twitter summary card with large image must be at least 280x150px -->
-<!--{%if page_image %}
+{%if page_image %}
   <meta name="twitter:image:src" content="{{ page_image }}" />
   <meta name="twitter:image" content="{{ page_image }}" />
 {%endif %}
-<meta name="twitter:url" content="{{ canonical_url }}" />-->
+<meta name="twitter:url" content="{{ canonical_url }}" />
 
 <!-- Open Graph data -->
 <meta property="og:title" content="{{ page_title }}" />

--- a/_includes/social-metatags.html
+++ b/_includes/social-metatags.html
@@ -13,12 +13,12 @@
 {% if page.author.name or page.facebook.publisher_id %}
   {% assign page_author = page.author.name | default: nil | escape %}
   {% assign facebook_publisher_id = page.facebook.publisher_id | default: nil | escape %}
-  {% assign twitter_creator = page.twitter.username | default: site.twitter.site | default: nil | escape %}
+  <!--{% assign twitter_creator = page.twitter.username | default: site.twitter.site | default: nil | escape %}-->
   {% assign facebook_authors = page.facebook.authors | default: nil | escape %}
 {% else %}
   {% assign page_author = site.author.name | default: nil | escape %}
   {% assign facebook_publisher_id = site.facebook.publisher_id | default: nil | escape %}
-  {% assign twitter_creator = site.twitter.username | default: nil | escape %}
+  <!--{% assign twitter_creator = site.twitter.username | default: nil | escape %}-->
   {% assign facebook_authors = site.facebook.authors | default: nil | escape %}
 {% endif %}
 
@@ -58,7 +58,7 @@
 {%endif %}
 
 <!-- Twitter Card data -->
-<meta name="twitter:card" content="{{ page_image }}" />
+<!--<meta name="twitter:card" content="{{ page_image }}" />
 
 {%if site.twitter.site %}
   <meta name="twitter:site" content="@{{ site.twitter.site }}" />
@@ -72,11 +72,11 @@
 {%endif %}
 
 <!-- Twitter summary card with large image must be at least 280x150px -->
-{%if page_image %}
+<!--{%if page_image %}
   <meta name="twitter:image:src" content="{{ page_image }}" />
   <meta name="twitter:image" content="{{ page_image }}" />
 {%endif %}
-<meta name="twitter:url" content="{{ canonical_url }}" />
+<meta name="twitter:url" content="{{ canonical_url }}" />-->
 
 <!-- Open Graph data -->
 <meta property="og:title" content="{{ page_title }}" />


### PR DESCRIPTION
This pull-request solves the last remaining bugs in relation to the social meta tags feature. The social meta tags now work on Discord, Facebook and Twitter displaying the book cover, project description and title. Lastly, we fixed the issue of the logo not being displayed on the pages of the book other than the main page.