### PR TITLE
Changed absolute link to relative link on logo

### DIFF
--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,6 +1,6 @@
 <!-- Logo -->
 <div id="logo">
-  <a href="{{- '/' | absolute_url -}}" id="home-link">
+  <a href="{{- '/' | relative_url -}}" id="home-link">
     <span class="image avatar48"><img src="{{- 'assets/images/avatar.png' | relative_url -}}" alt="{{- site.author | default: 'unknown author' | prepend: 'Avatar of ' -}}" /></span>
     <h1 id="title">{{- site.title -}}</h1>
     <p>{{- site.subtitle -}}</p>


### PR DESCRIPTION
This pull request changes the link on the logo in the side bar from an absolute link to a relative one.

This ensures that on https://ea-tel.eu/detel-book/ clicking the top left logo does not lead to https://ea-tel.github.io/detel-book/ but stays on https://ea-tel.eu/detel-book/.